### PR TITLE
fixing bower.json main field

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,6 +10,9 @@
     "perfmatters",
     "angularjs"
   ],
+  "main": [
+    "lib/ngpLocalEventDirs.js"
+  ],
   "license": "MIT",
   "ignore": [
     "**/.*",


### PR DESCRIPTION
In order for the ng-perf bower package to be properly useful to people using automated injection of bower dependencies in their build pipelines, every bower package should specify a "main" field. I've added one for you, for only the local directives js file, not the angular-1.2-only jQuery.fn.data perf fix.
